### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/localtuya/manifest.json
+++ b/custom_components/localtuya/manifest.json
@@ -1,7 +1,8 @@
 {
   "domain": "localtuya",
-  "name": "LocalTuya integration",
-  "documentation": "https://github.com/rospogrigio/localtuya/",
+  "name": "LocalTuya integration (w/ climate-1.1.2)",
+  "version": "3.2.3",
+  "documentation": "https://github.com/ArtistAOP/localtuya/",
   "dependencies": [],
   "codeowners": [
     "@rospogrigio", "@postlund"


### PR DESCRIPTION
Update manifest.json adding version, cause of this error [homeassistant.loader] The custom integration 'localtuya' does not have a version key in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details